### PR TITLE
Add host ip detection for DOGSTATSD_HOST and ETCD_CLIENT_URL defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ RUN apk --no-cache add py-pip
 
 ENV ETCD_DATA_DIR=/var/lib/etcd
 
+COPY /entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
+
 # Copy requirements.txt separately so pip install step can be cached
 COPY /requirements.txt /opt/etcd-backup/requirements.txt
 RUN pip install -r /opt/etcd-backup/requirements.txt

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ leader.
 The backup script uses boto3 under the hood, so any [authentication method](http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials)
 used by boto will work here, including environment variables and IAM instance profiles.
 
+## Host IP Detection
+
+Any host IPs that would normally default to localhost will default to the host IP when running
+in the container.  See [entrypoint.sh](entrypoint.sh).
+
 ## Datadog support
 
 If you supply the appropriate environment variables, the backup script will send metrics to Datadog.  See the

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+host_ip=$(route -n | grep "^0\.0\.0\.0" | awk '{ print $2 }')
+
+if [ -z "$DOGSTATSD_HOST" ]; then
+  export DOGSTATSD_HOST="$host_ip"
+fi
+
+if [ -z "$ETCD_CLIENT_URL" ]; then
+  export ETCD_CLIENT_URL="http://$host_ip:2379"
+fi
+
+exec "$@"

--- a/etcd-backup.py
+++ b/etcd-backup.py
@@ -36,18 +36,11 @@ Required env vars:
 
 Optional env vars:
   BACKUP_INTERVAL_SEC: number of seconds to wait between backup runs (default: 60)
+  DOGSTATSD_METRICS_ENABLED: as the name says (default: false)
   ETCD_CLIENT_URL: URL for reaching etcd to detect if we are talking to the master (default: http://localhost:2379)
   ETCD_DATA_DIR: etcd data directory  (default: /var/lib/etcd)
   LOG_LEVEL: as the name says (default: INFO)
   RUN_ONCE: if "true", run once and exit
-
-Datadog support:
-
-    If these keys are set, we will send metrics to dogstatsd.
-    See the submit_metrics method.
-
-    DOGSTATSD_HOST: Host where dogstatsd is listening (default: "")
-    DOGSTATSD_PORT: Port where dogstatsd is listening (default: 8125)
 """ % (sys.argv[0])
     print(message)
 
@@ -153,10 +146,9 @@ def get_file_md5_sum(file_path):
 
 
 def submit_metrics(bucket, prefix, file_size_bytes):
-    host = os.getenv('DOGSTATSD_HOST')
-    port = os.getenv('DOGSTATSD_PORT', 8125)
-
-    if host:
+    if os.getenv('DOGSTATSD_METRICS_ENABLED') == 'true':
+        host = os.getenv('DOGSTATSD_HOST')
+        port = os.getenv('DOGSTATSD_PORT', 8125)
         statsd = datadog.dogstatsd.DogStatsd(host=host, port=port)
         statsd.increment(metric='etcd_backup.s3_upload.bytes',
                          value=file_size_bytes,

--- a/etcd-backup.py
+++ b/etcd-backup.py
@@ -36,11 +36,19 @@ Required env vars:
 
 Optional env vars:
   BACKUP_INTERVAL_SEC: number of seconds to wait between backup runs (default: 60)
-  DOGSTATSD_METRICS_ENABLED: as the name says (default: false)
-  ETCD_CLIENT_URL: URL for reaching etcd to detect if we are talking to the master (default: http://localhost:2379)
+  ETCD_CLIENT_URL: URL for reaching etcd to detect if we are talking to the master
   ETCD_DATA_DIR: etcd data directory  (default: /var/lib/etcd)
   LOG_LEVEL: as the name says (default: INFO)
   RUN_ONCE: if "true", run once and exit
+
+Dogstatsd settings:
+  DOGSTATSD_METRICS_ENABLED: as the name says (default: false)
+
+  If Dogstatsd metrics are enabled, the following vars are used:
+
+      DOGSTATSD_HOST
+      DOGSTATSD_PORT (default: 8125)
+
 """ % (sys.argv[0])
     print(message)
 
@@ -51,7 +59,7 @@ def main():
     s3_bucket = get_required_env_var('S3_BUCKET')
     s3_prefix = get_required_env_var('S3_PREFIX')
     run_once = os.getenv("RUN_ONCE") == "true"
-    etcd_client_url = os.getenv("ETCD_CLIENT_URL", "http://localhost:2379")
+    etcd_client_url = os.getenv("ETCD_CLIENT_URL")
 
     while True:
         logging.info("Starting etcd-backup, running backup every %s seconds.", backup_interval)


### PR DESCRIPTION
This makes it much easier to run without having to add wrapper code outside of the container for getting the host IP.